### PR TITLE
Bugfix: Fix failing test `test_read_holmgard_gym.py` (Resolve Issue #18)

### DIFF
--- a/gym_md/envs/setting.py
+++ b/gym_md/envs/setting.py
@@ -105,7 +105,8 @@ class Setting(Singleton):
 
         actual_stage_file: str = prop_files_dir[prop_files_dir_lowercased.index(target_stage_file.lower())]
 
-        json_path = path.join(file_dir, "props", f"{stage_name}.json")
+        json_path: str = path.join(file_dir, "props", actual_stage_file)
+
         with open(json_path, "r") as f:
             data = json.load(f)
             props_config = PropsConfig(**data)

--- a/gym_md/envs/setting.py
+++ b/gym_md/envs/setting.py
@@ -98,6 +98,7 @@ class Setting(Singleton):
 
         """
         file_dir: str = path.dirname(__file__)
+        target_stage_file: str = f"{stage_name}.json"
         json_path = path.join(file_dir, "props", f"{stage_name}.json")
         with open(json_path, "r") as f:
             data = json.load(f)

--- a/gym_md/envs/setting.py
+++ b/gym_md/envs/setting.py
@@ -8,6 +8,7 @@ import json
 from copy import deepcopy
 from os import path, listdir
 from typing import Dict, Final, List
+from platform import system as platform_system
 
 from gym_md.envs import definition
 from gym_md.envs.config.props_config import PropsConfig, RewardsConfig
@@ -99,13 +100,13 @@ class Setting(Singleton):
         """
         file_dir: str = path.dirname(__file__)
         target_stage_file: str = f"{stage_name}.json"
+        json_path: str = path.join(file_dir, "props", target_stage_file)
 
-        prop_files_dir: list = listdir(path.join(file_dir, "props"))
-        prop_files_dir_lowercased: list = [file_name.lower() for file_name in prop_files_dir]
-
-        actual_stage_file: str = prop_files_dir[prop_files_dir_lowercased.index(target_stage_file.lower())]
-
-        json_path: str = path.join(file_dir, "props", actual_stage_file)
+        if platform_system().lower() == "linux":
+            prop_files_dir: list = listdir(path.join(file_dir, "props"))
+            prop_files_dir_lowercased: list = [file_name.lower() for file_name in prop_files_dir]
+            actual_stage_file: str = prop_files_dir[prop_files_dir_lowercased.index(target_stage_file.lower())]
+            json_path: str = path.join(file_dir, "props", actual_stage_file)
 
         with open(json_path, "r") as f:
             data = json.load(f)

--- a/gym_md/envs/setting.py
+++ b/gym_md/envs/setting.py
@@ -6,7 +6,7 @@
 """
 import json
 from copy import deepcopy
-from os import path
+from os import path, listdir
 from typing import Dict, Final, List
 
 from gym_md.envs import definition

--- a/gym_md/envs/setting.py
+++ b/gym_md/envs/setting.py
@@ -99,6 +99,12 @@ class Setting(Singleton):
         """
         file_dir: str = path.dirname(__file__)
         target_stage_file: str = f"{stage_name}.json"
+
+        prop_files_dir: list = listdir(path.join(file_dir, "props"))
+        prop_files_dir_lowercased: list = [file_name.lower() for file_name in prop_files_dir]
+
+        actual_stage_file: str = prop_files_dir[prop_files_dir_lowercased.index(target_stage_file.lower())]
+
         json_path = path.join(file_dir, "props", f"{stage_name}.json")
         with open(json_path, "r") as f:
             data = json.load(f)

--- a/gym_md/envs/setting.py
+++ b/gym_md/envs/setting.py
@@ -97,7 +97,7 @@ class Setting(Singleton):
         PropsConfig
 
         """
-        file_dir = path.dirname(__file__)
+        file_dir: str = path.dirname(__file__)
         json_path = path.join(file_dir, "props", f"{stage_name}.json")
         with open(json_path, "r") as f:
             data = json.load(f)


### PR DESCRIPTION
## Overview 
This PR aims to address the failing test `test_read_holmgard_gym.py`. The _tests/envs/test_read_holmgard_gym.py_ test fails
on linux based filesystems. This is because linux based filesystems are "file-name case-sensitive". Please see Issue https://github.com/ganyariya/gym-md/issues/18 for detail.

## Changes Made
Modify the `def read_settings(stage_name: str) -> PropsConfig` static method within the `gym_md/envs/setting.py` file to cater for the case-sensitive file names.

## Testing output after changes
```bash
========================================= test session starts =========================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/***/***/gym-md
collected 20 items                                                                                    

tests/envs/test_change_rewards.py .                                                             [  5%]
tests/envs/test_config.py ...                                                                   [ 20%]
tests/envs/test_grid.py .                                                                       [ 25%]
tests/envs/test_gym.py ..                                                                       [ 35%]
tests/envs/test_path.py ..                                                                      [ 45%]
tests/envs/test_random.py .                                                                     [ 50%]
tests/envs/test_read_holmgard_gym.py ...                                                        [ 65%]
tests/envs/test_setting.py .                                                                    [ 70%]
tests/envs/agents/test_agent.py ......                                                          [100%]

========================================= 20 passed in 15.31s =========================================
```