### PR TITLE
Include pydantic dependency in setup.cfg (Resolves Issue #16 )

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,6 @@ include_package_data = True
 install_requires =
     gym
     matplotlib
+    pydantic
 packages = find:
 zip_safe = False


### PR DESCRIPTION
## Overview
After a clean/new install of _gym_md_ from _pypi_, I noticed that the `pydantic` was not installed during the _pip_ install of gym_md. Please see Issue #16 for more detail. This PR aims to address the missing _pydantic_ dependency when gym-md is 'pip' installed, by adding the _pydantic_ python package to the _install_requires_ list within setup.cfg.

## Changes
- [Include pydantic dependency in setup.cfg](https://github.com/ganyariya/gym-md/commit/59eae8f316808ae9062292c46656917371918e47)
