### PR TITLE
Fix module import for pather warning during Sphinx doc build

### DIFF
--- a/source/gym_md.envs.agent.rst
+++ b/source/gym_md.envs.agent.rst
@@ -31,7 +31,7 @@ gym\_md.envs.agent.move\_info module
 gym\_md.envs.agent.path module
 ------------------------------
 
-.. automodule:: gym_md.envs.agent.path
+.. automodule:: gym_md.envs.agent.pather
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
## Overview
This pull request aims to fix the following warning thrown during the Sphinx documentation (`pipenv run build`) build process:
```bash
WARNING: autodoc: failed to import module 'path' from module 'gym_md.envs.agent';
the following exception was raised: No module named 'gym_md.envs.agent.path'
```

## Original build output, before fix:
```bash
Running Sphinx v4.2.0
WARNING: html_static_path entry '_static' does not exist
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] gym_md.envs.agent                                                                  
/home/***/***/gym-md/gym_md/envs/agent/agent.py:docstring of gym_md.envs.agent.agent.Agent.select_action:8: WARNING: Inline strong start-string without end-string.
WARNING: autodoc: failed to import module 'path' from module 'gym_md.envs.agent'; the following exception was raised:
No module named 'gym_md.envs.agent.path'
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/***/***/gym-md/source/modules.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] index                                                                               
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 4 warnings.

The HTML pages are in build.
```
## Original build output, after fix:
```bash
Running Sphinx v4.2.0
WARNING: html_static_path entry '_static' does not exist
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] gym_md.envs.agent                                                                  
/home/***/***/gym-md/gym_md/envs/agent/agent.py:docstring of gym_md.envs.agent.agent.Agent.select_action:8: WARNING: Inline strong start-string without end-string.
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/***/***/gym-md/source/modules.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] index                                                                               
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 3 warnings.

The HTML pages are in build
```