### PR TITLE
Documentation/fix selected pypi readme image render and broken link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2012-2022 Scott Chacon and others
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,21 @@
-Copyright (c) 2012-2022 Scott Chacon and others
+MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Copyright (c) 2022 Ganyariya
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gym-md
 ## 日本語のREADME.md
-The original Japanese README can be found [here](README/japan/README.md).
+The original Japanese README can be found [here](https://github.com/ganyariya/gym-md/blob/main/README/japan/README.md).
 
 ## Contents
 * [Overview](#overview)
@@ -23,18 +23,21 @@ gym-md is a python reimplementation[^1] of the dungeon exploration game [MiniDun
 MiniDungeons[^2] is a roguelike dungeon exploration game created as a benchmark research domain for modeling decision-making styles of human players[^4]. A Java implementation of MiniDungeons can be found [here](https://github.com/sentientdesigns/minidungeons).
 
 <p align="center">
-    <img src="/README/resources/screen.png" width="250px">
+    <img src="https://github.com/ganyariya/gym-md/blob/main/README/resources/screen.png?raw=true" width="250px">
 </p>
 
 [^1]: Y. Iwasaki. and K. Hasebe., “A framework for generating playstyles
 of game ai with clustering of play logs,” in Proceedings of the 14th
 International Conference on Agents and Artificial Intelligence - Volume
 3: ICAART,, INSTICC. SciTePress, 2022, pp. 605–612.
+
 [^2]: C. Holmgård, A. Liapis, J. Togelius, and G. N. Yannakakis, “Evolving
 personas for player decision modeling,” in 2014 IEEE Conference on
 Computational Intelligence and Games, 2014, pp. 1–8.
+
 [^3]: G. Brockman, V. Cheung, L. Pettersson, J. Schneider, J. Schulman, J. Tang, and W. Zaremba, “Openai gym,” arXiv preprint
 arXiv:1606.01540, 2016.
+
 [^4]: A. Liapis, “Minidungeons”, website, 2022. Accessed on: Mar. 27, 2022. [Online].
 Available: http://antoniosliapis.com/projects/project_minidungeons.php
 
@@ -116,7 +119,7 @@ for _ in range(TRY_OUT):
 ### Overview
 
 <p align="center">
-    <img src="/README/resources/gym-md-env-action-loop.drawio.svg" width="600px">
+    <img src="https://github.com/ganyariya/gym-md/blob/main/README/resources/gym-md-env-action-loop.drawio.svg?raw=true" width="600px">
 </p>
 
 Click [here](https://gym.openai.com/docs/) for a _Getting Started with Gym_ overview.

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,27 @@ author_email = ganariya2525@gmail.com
 license = MIT
 long_description = file: README.md
 long_description_content_type = text/markdown
+license_file = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Artificial Intelligence
+    Natural Language :: Japanese
+    Natural Language :: English
+project_urls =
+    Bug Tracker = https://github.com/ganyariya/gym-md/issues
+    Documentation = https://github.com/ganyariya/gym-md/blob/main/README.md
+    Source Code = https://github.com/ganyariya/gym-md
 
 [options]
 include_package_data = True


### PR DESCRIPTION
## Overview
This pull request (PR) aims to fix the gym-md pypi broken image rendering (see below). The only other relative link changed is the link to the Japanese README file. 

We should potentially discuss a general solution for fixing the relative repo links breaking when the pypi readme is created during package upload.

## Other changes
- This PR will also add the MIT license file to the repo
- Define the gym-md pypi classifiers and other meta

![broken_overview_image_and_ref_formatting](https://user-images.githubusercontent.com/13453134/165920389-b935e5cf-6cf8-47cb-aea3-b28bc623c7eb.png)
![broken_gym_md_env_image](https://user-images.githubusercontent.com/13453134/165920421-2a7259d7-9765-418e-b770-f021d7f28cd9.png)



